### PR TITLE
Fix periodic (vale) check config

### DIFF
--- a/.github/workflows/periodic-style-checks.yml
+++ b/.github/workflows/periodic-style-checks.yml
@@ -11,7 +11,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: "sp-docs"
+        working-directory: "docs"
     steps:
       - uses: actions/checkout@v4
       - name: Run vale

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -13,5 +13,4 @@ __pycache__
 .idea/
 .vscode/
 .sphinx/styles/*
-.sphinx/vale.ini
 sp-docs/_build

--- a/docs/.sphinx/vale.ini
+++ b/docs/.sphinx/vale.ini
@@ -1,0 +1,34 @@
+StylesPath = styles
+MinAlertLevel = warning
+Vocab = Canonical
+IgnoredScopes = 
+
+[*.{md,txt,rst,html}]
+
+BasedOnStyles = Canonical
+
+# this enumerates all of the current rules with their suggested
+# severity level. This makes it easier to edit for specific use cases
+
+Canonical.001-English-words-spelling-suggestions  = suggest
+Canonical.003-Ubuntu-names-versions = warning              
+Canonical.004-Canonical-product-names = warning           
+Canonical.005-Industry-product-names = warning             
+Canonical.006-Contractions-forbidden = warning             
+Canonical.007-Headings-sentence-case = suggest           
+Canonical.008-Headings-no-period = warning               
+Canonical.009-Headings-no-links = error                
+Canonical.010-Punctuation-double-spaces = warning         
+Canonical.011-Headings-not-followed-by-heading = warning 
+Canonical.013-Spell-out-numbers-below-10 = suggest                                   
+Canonical.014a-Numbers-greater-than-nine-should-be-in-numeric-form = suggest         
+Canonical.014b-Numbers-with-five-or-more-digits-must-have-comma-separators  = suggest
+Canonical.016-No-inline-comments = warning
+Canonical.017-Avoid-long-code-blocks = warning
+Canonical.019-no-google-drive-images = error
+Canonical.020-Cliche-words-and-phrases = suggest
+Canonical.025a-latinisms-with-english-equivalents = suggest
+Canonical.025b-latinisms-to-reconsider = suggest
+Canonical.025c-latinisms-to-avoid = warning
+Canonical.400-Enforce-inclusive-terms = warning
+Canonical.500-Repeated-words = NO

--- a/docs/Makefile.sp
+++ b/docs/Makefile.sp
@@ -100,7 +100,6 @@ sp-clean: sp-clean-doc
 	rm -rf $(VENVDIR)
 	rm -rf $(SPHINXDIR)/node_modules/
 	rm -rf $(SPHINXDIR)/styles
-	rm -rf $(SPHINXDIR)/vale.ini
 
 sp-clean-doc:
 	git clean -fx "$(BUILDDIR)"


### PR DESCRIPTION
This fixes several problems with the periodic style check:

- working dir in GH Action
- persistent `vale.ini` (to keep incl. lang. check as warning only)