### PR TITLE
Update and improve README and contributing.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,18 @@ for hardware that is not yet supported by the Ubuntu distribution.
 It will guide you through these steps of your project:
 
 * Collect requirements
-* Setup Launchpad
+* Set up Launchpad
 * Build packages
 * Build the image
 * Test the image
 
 ## Project homepage
 
-The project git repository is located at
-https://github.com/canonical/risc-v-cookbook/.
+The project Git repository is located at [github.com/canonical/risc-v-cookbook](https://github.com/canonical/risc-v-cookbook/).
 
-The generated documentation is hosted at
-https://canonical-risc-v-cookbook.readthedocs-hosted.com/en/latest/.
+The generated documentation is hosted at [canonical-risc-v-cookbook.readthedocs-hosted.com](https://canonical-risc-v-cookbook.readthedocs-hosted.com/en/latest/).
 
-The continuous integration results are available at
-https://github.com/canonical/risc-v-cookbook/actions/.
+The continuous integration results are available at [risc-v-cookbook/actions](https://github.com/canonical/risc-v-cookbook/actions/).
 
 ## Building
 
@@ -28,16 +25,16 @@ https://github.com/canonical/risc-v-cookbook/actions/.
     make html
     make spellcheck
     make linkcheck
-    make wokecheck
+    make vale
 
-Serve the HTML pages on http://127.0.0.1:8080
+Serve the HTML pages on [http://127.0.0.1:8000](http://127.0.0.1:8080).
 
     make serve
 
 ## How to contribute
 
-See doc/contributing.rst
+See `docs/contributing.rst`.
 
 ## License
 
-CC-BY-SA-4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+[CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -130,8 +130,7 @@ Formatting
 ~~~~~~~~~~
 
 We use `Sphinx <https://www.sphinx-doc.org>`_ for generating the
-documentation from
-`reStructured Text <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_.  .. wokeignore:rule=master
+documentation from **reStructured Text**. Refer to our `reStructuredText style guide <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/>`_ for basic guidance.
 
 We tend to use a maximum of 80 characters per line.
 


### PR DESCRIPTION
- Few formatting, language, and mark-up fixes in README.
- Change of the link to rST docs in `contributing.rst`.