### PR TITLE
create_image: add qemu-system-riscv64 dependency

### DIFF
--- a/docs/tutorial/create_image.rst
+++ b/docs/tutorial/create_image.rst
@@ -38,7 +38,7 @@ For running the image in a virtual machine install the runtime dependencies.
 
 .. prompt:: text $ auto
 
-    $ sudo apt-get install opensbi u-boot-qemu
+    $ sudo apt-get install opensbi qemu-system-riscv64 u-boot-qemu
 
 Navigate to the image and change the owner.
 


### PR DESCRIPTION
qemu-system-riscv64 is a virtual package which expands to qemu-system-misc on Ubuntu 24.04 and to qemu-system-riscv on Ubuntu 25.04.